### PR TITLE
Added marker interfaces for parameter types

### DIFF
--- a/src/Entity/Parameters/BodyParameter.php
+++ b/src/Entity/Parameters/BodyParameter.php
@@ -7,6 +7,7 @@
 namespace Epfremme\Swagger\Entity\Parameters;
 
 use Epfremme\Swagger\Entity\Schemas\SchemaInterface;
+use Epfremme\Swagger\Type\BodyParameterInterface;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -15,7 +16,7 @@ use JMS\Serializer\Annotation as JMS;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters
  */
-class BodyParameter extends AbstractParameter
+class BodyParameter extends AbstractParameter implements BodyParameterInterface
 {
     /**
      * @JMS\Since("2.0")

--- a/src/Entity/Parameters/FormParameter/ArrayType.php
+++ b/src/Entity/Parameters/FormParameter/ArrayType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\ArrayTypeInterface;
+use Epfremme\Swagger\Type\FormParameterInterface;
 
 /**
  * Class ArrayType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\FormParameter
  */
-class ArrayType extends AbstractTypedParameter
+class ArrayType extends AbstractTypedParameter implements FormParameterInterface, ArrayTypeInterface
 {
     use Primitives\ArrayPrimitiveTrait;
 }

--- a/src/Entity/Parameters/FormParameter/BooleanType.php
+++ b/src/Entity/Parameters/FormParameter/BooleanType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\BooleanTypeInterface;
+use Epfremme\Swagger\Type\FormParameterInterface;
 
 /**
  * Class BooleanType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\FormParameter
  */
-class BooleanType extends AbstractTypedParameter
+class BooleanType extends AbstractTypedParameter implements FormParameterInterface, BooleanTypeInterface
 {
     use Primitives\BooleanPrimitiveTrait;
 }

--- a/src/Entity/Parameters/FormParameter/FileType.php
+++ b/src/Entity/Parameters/FormParameter/FileType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\FileTypeInterface;
+use Epfremme\Swagger\Type\FormParameterInterface;
 
 /**
  * Class FileType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\FormParameter
  */
-class FileType extends AbstractTypedParameter
+class FileType extends AbstractTypedParameter implements FormParameterInterface, FileTypeInterface
 {
 
 }

--- a/src/Entity/Parameters/FormParameter/IntegerType.php
+++ b/src/Entity/Parameters/FormParameter/IntegerType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\FormParameterInterface;
+use Epfremme\Swagger\Type\NumericTypeInterface;
 
 /**
  * Class IntegerType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\FormParameter
  */
-class IntegerType extends AbstractTypedParameter
+class IntegerType extends AbstractTypedParameter implements FormParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/FormParameter/NumberType.php
+++ b/src/Entity/Parameters/FormParameter/NumberType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\FormParameterInterface;
+use Epfremme\Swagger\Type\NumericTypeInterface;
 
 /**
  * Class NumberType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\FormParameter
  */
-class NumberType extends AbstractTypedParameter
+class NumberType extends AbstractTypedParameter implements FormParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/FormParameter/StringType.php
+++ b/src/Entity/Parameters/FormParameter/StringType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\FormParameterInterface;
+use Epfremme\Swagger\Type\StringTypeInterface;
 
 /**
  * Class StringType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\FormParameter
  */
-class StringType extends AbstractTypedParameter
+class StringType extends AbstractTypedParameter implements FormParameterInterface, StringTypeInterface
 {
     use Primitives\StringPrimitiveTrait;
 }

--- a/src/Entity/Parameters/HeaderParameter/ArrayType.php
+++ b/src/Entity/Parameters/HeaderParameter/ArrayType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\ArrayTypeInterface;
+use Epfremme\Swagger\Type\HeaderParameterInterface;
 
 /**
  * Class ArrayType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\HeaderParameter
  */
-class ArrayType extends AbstractTypedParameter
+class ArrayType extends AbstractTypedParameter implements HeaderParameterInterface, ArrayTypeInterface
 {
     use Primitives\ArrayPrimitiveTrait;
 }

--- a/src/Entity/Parameters/HeaderParameter/BooleanType.php
+++ b/src/Entity/Parameters/HeaderParameter/BooleanType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\BooleanTypeInterface;
+use Epfremme\Swagger\Type\HeaderParameterInterface;
 
 /**
  * Class BooleanType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\HeaderParameter
  */
-class BooleanType extends AbstractTypedParameter
+class BooleanType extends AbstractTypedParameter implements HeaderParameterInterface, BooleanTypeInterface
 {
     use Primitives\BooleanPrimitiveTrait;
 }

--- a/src/Entity/Parameters/HeaderParameter/IntegerType.php
+++ b/src/Entity/Parameters/HeaderParameter/IntegerType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\HeaderParameterInterface;
+use Epfremme\Swagger\Type\NumericTypeInterface;
 
 /**
  * Class IntegerType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\HeaderParameter
  */
-class IntegerType extends AbstractTypedParameter
+class IntegerType extends AbstractTypedParameter implements HeaderParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/HeaderParameter/NumberType.php
+++ b/src/Entity/Parameters/HeaderParameter/NumberType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\HeaderParameterInterface;
+use Epfremme\Swagger\Type\NumericTypeInterface;
 
 /**
  * Class NumberType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\HeaderParameter
  */
-class NumberType extends AbstractTypedParameter
+class NumberType extends AbstractTypedParameter implements HeaderParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/HeaderParameter/StringType.php
+++ b/src/Entity/Parameters/HeaderParameter/StringType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\HeaderParameterInterface;
+use Epfremme\Swagger\Type\StringTypeInterface;
 
 /**
  * Class StringType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\HeaderParameter
  */
-class StringType extends AbstractTypedParameter
+class StringType extends AbstractTypedParameter implements HeaderParameterInterface, StringTypeInterface
 {
     use Primitives\StringPrimitiveTrait;
 }

--- a/src/Entity/Parameters/PathParameter/BooleanType.php
+++ b/src/Entity/Parameters/PathParameter/BooleanType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\PathParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\BooleanTypeInterface;
+use Epfremme\Swagger\Type\PathParameterInterface;
 
 /**
  * Class BooleanType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\PathParameter
  */
-class BooleanType extends AbstractTypedParameter
+class BooleanType extends AbstractTypedParameter implements PathParameterInterface, BooleanTypeInterface
 {
     use Primitives\BooleanPrimitiveTrait;
 }

--- a/src/Entity/Parameters/PathParameter/IntegerType.php
+++ b/src/Entity/Parameters/PathParameter/IntegerType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\PathParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\NumericTypeInterface;
+use Epfremme\Swagger\Type\PathParameterInterface;
 
 /**
  * Class IntegerType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\PathParameter
  */
-class IntegerType extends AbstractTypedParameter
+class IntegerType extends AbstractTypedParameter implements PathParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/PathParameter/StringType.php
+++ b/src/Entity/Parameters/PathParameter/StringType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\PathParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\PathParameterInterface;
+use Epfremme\Swagger\Type\StringTypeInterface;
 
 /**
  * Class StringType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\PathParameter
  */
-class StringType extends AbstractTypedParameter
+class StringType extends AbstractTypedParameter implements PathParameterInterface, StringTypeInterface
 {
     use Primitives\StringPrimitiveTrait;
 }

--- a/src/Entity/Parameters/QueryParameter/ArrayType.php
+++ b/src/Entity/Parameters/QueryParameter/ArrayType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\ArrayTypeInterface;
+use Epfremme\Swagger\Type\QueryParameterInterface;
 
 /**
  * Class ArrayType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\QueryParameter
  */
-class ArrayType extends AbstractTypedParameter
+class ArrayType extends AbstractTypedParameter implements QueryParameterInterface, ArrayTypeInterface
 {
     use Primitives\ArrayPrimitiveTrait;
 }

--- a/src/Entity/Parameters/QueryParameter/BooleanType.php
+++ b/src/Entity/Parameters/QueryParameter/BooleanType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\BooleanTypeInterface;
+use Epfremme\Swagger\Type\QueryParameterInterface;
 
 /**
  * Class BooleanType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\QueryParameter
  */
-class BooleanType extends AbstractTypedParameter
+class BooleanType extends AbstractTypedParameter implements QueryParameterInterface, BooleanTypeInterface
 {
     use Primitives\BooleanPrimitiveTrait;
 }

--- a/src/Entity/Parameters/QueryParameter/IntegerType.php
+++ b/src/Entity/Parameters/QueryParameter/IntegerType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\NumericTypeInterface;
+use Epfremme\Swagger\Type\QueryParameterInterface;
 
 /**
  * Class IntegerType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\QueryParameter
  */
-class IntegerType extends AbstractTypedParameter
+class IntegerType extends AbstractTypedParameter implements QueryParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/QueryParameter/NumberType.php
+++ b/src/Entity/Parameters/QueryParameter/NumberType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\NumericTypeInterface;
+use Epfremme\Swagger\Type\QueryParameterInterface;
 
 /**
  * Class NumberType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\QueryParameter
  */
-class NumberType extends AbstractTypedParameter
+class NumberType extends AbstractTypedParameter implements QueryParameterInterface, NumericTypeInterface
 {
     use Primitives\NumericPrimitiveTrait;
 }

--- a/src/Entity/Parameters/QueryParameter/StringType.php
+++ b/src/Entity/Parameters/QueryParameter/StringType.php
@@ -8,6 +8,8 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use Epfremme\Swagger\Type\QueryParameterInterface;
+use Epfremme\Swagger\Type\StringTypeInterface;
 
 /**
  * Class StringType
@@ -15,7 +17,7 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  * @package Epfremme\Swagger
  * @subpackage Entity\Parameters\QueryParameter
  */
-class StringType extends AbstractTypedParameter
+class StringType extends AbstractTypedParameter implements QueryParameterInterface, StringTypeInterface
 {
     use Primitives\StringPrimitiveTrait;
 }

--- a/src/Type/ArrayTypeInterface.php
+++ b/src/Type/ArrayTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for array types.
+ */
+interface ArrayTypeInterface
+{
+}

--- a/src/Type/BodyParameterInterface.php
+++ b/src/Type/BodyParameterInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for body parameter types.
+ */
+interface BodyParameterInterface
+{
+}

--- a/src/Type/BooleanTypeInterface.php
+++ b/src/Type/BooleanTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for boolean types.
+ */
+interface BooleanTypeInterface
+{
+}

--- a/src/Type/FileTypeInterface.php
+++ b/src/Type/FileTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for file types.
+ */
+interface FileTypeInterface
+{
+}

--- a/src/Type/FormParameterInterface.php
+++ b/src/Type/FormParameterInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for form parameter types.
+ */
+interface FormParameterInterface
+{
+}

--- a/src/Type/HeaderParameterInterface.php
+++ b/src/Type/HeaderParameterInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for header parameter types.
+ */
+interface HeaderParameterInterface
+{
+}

--- a/src/Type/NullTypeInterface.php
+++ b/src/Type/NullTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for null types.
+ */
+interface NullTypeInterface
+{
+}

--- a/src/Type/NumericTypeInterface.php
+++ b/src/Type/NumericTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for numeric types.
+ */
+interface NumericTypeInterface
+{
+}

--- a/src/Type/ObjectTypeInterface.php
+++ b/src/Type/ObjectTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for object types.
+ */
+interface ObjectTypeInterface
+{
+}

--- a/src/Type/PathParameterInterface.php
+++ b/src/Type/PathParameterInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for path parameter types.
+ */
+interface PathParameterInterface
+{
+}

--- a/src/Type/QueryParameterInterface.php
+++ b/src/Type/QueryParameterInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for query parameter types.
+ */
+interface QueryParameterInterface
+{
+}

--- a/src/Type/StringTypeInterface.php
+++ b/src/Type/StringTypeInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Epfremme\Swagger\Type;
+
+/**
+ * Marker interface for string types.
+ */
+interface StringTypeInterface
+{
+}


### PR DESCRIPTION
Since interfaces cannot be added to traits (lacking feature in PHP), I've added a set of marker interfaces on parameters and their types.

This makes it easier to perform `instanceof` checks to decide what behavior to use for different parameters and types when, for example, generating a client-api based on this schema.

Psuedo example (by no means actual code :stuck_out_tongue:):
```php
$ast_params = [];

foreach ($operation->getParameters() as $parameter) {
   if ($parameter instanceof QueryParameterInterface) {
      $query_param = new QueryParameterGenerator($parameter);
      if ($parameter instanceof StringTypeInterface) {
         $ast_params[] = $query_param->getStringNode();
      }
   }
}
```

Currently we need to check which traits are implemented in a type, which is kind of finicky... This PR aims to make these kind of checks a little easier.
