### PR TITLE
Fix parameter's default values being cast to string

### DIFF
--- a/src/Entity/Parameters/AbstractTypedParameter.php
+++ b/src/Entity/Parameters/AbstractTypedParameter.php
@@ -51,7 +51,6 @@ abstract class AbstractTypedParameter extends AbstractParameter
 
     /**
      * @JMS\Since("2.0")
-     * @JMS\Type("string")
      * @JMS\SerializedName("default")
      * @var string
      */

--- a/src/Entity/Parameters/FormParameter/ArrayType.php
+++ b/src/Entity/Parameters/FormParameter/ArrayType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class ArrayType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class ArrayType extends AbstractTypedParameter
 {
     use Primitives\ArrayPrimitiveTrait;
+
+    /**
+     * @JMS\Type("array")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/FormParameter/BooleanType.php
+++ b/src/Entity/Parameters/FormParameter/BooleanType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class BooleanType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class BooleanType extends AbstractTypedParameter
 {
     use Primitives\BooleanPrimitiveTrait;
+
+    /**
+     * @JMS\Type("boolean")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/FormParameter/FileType.php
+++ b/src/Entity/Parameters/FormParameter/FileType.php
@@ -6,8 +6,8 @@
  */
 namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
-use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class FileType
@@ -17,5 +17,9 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
  */
 class FileType extends AbstractTypedParameter
 {
-
+    /**
+     * @JMS\Type("string")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/FormParameter/IntegerType.php
+++ b/src/Entity/Parameters/FormParameter/IntegerType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class IntegerType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class IntegerType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("integer")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/FormParameter/NumberType.php
+++ b/src/Entity/Parameters/FormParameter/NumberType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class NumberType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class NumberType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("double")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/FormParameter/StringType.php
+++ b/src/Entity/Parameters/FormParameter/StringType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\FormParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class StringType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class StringType extends AbstractTypedParameter
 {
     use Primitives\StringPrimitiveTrait;
+
+    /**
+     * @JMS\Type("string")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/HeaderParameter/ArrayType.php
+++ b/src/Entity/Parameters/HeaderParameter/ArrayType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class ArrayType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class ArrayType extends AbstractTypedParameter
 {
     use Primitives\ArrayPrimitiveTrait;
+
+    /**
+     * @JMS\Type("array")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/HeaderParameter/BooleanType.php
+++ b/src/Entity/Parameters/HeaderParameter/BooleanType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class BooleanType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class BooleanType extends AbstractTypedParameter
 {
     use Primitives\BooleanPrimitiveTrait;
+
+    /**
+     * @JMS\Type("boolean")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/HeaderParameter/IntegerType.php
+++ b/src/Entity/Parameters/HeaderParameter/IntegerType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class IntegerType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class IntegerType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("integer")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/HeaderParameter/NumberType.php
+++ b/src/Entity/Parameters/HeaderParameter/NumberType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class NumberType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class NumberType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("double")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/HeaderParameter/StringType.php
+++ b/src/Entity/Parameters/HeaderParameter/StringType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\HeaderParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class StringType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class StringType extends AbstractTypedParameter
 {
     use Primitives\StringPrimitiveTrait;
+
+    /**
+     * @JMS\Type("string")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/PathParameter/BooleanType.php
+++ b/src/Entity/Parameters/PathParameter/BooleanType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\PathParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class BooleanType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class BooleanType extends AbstractTypedParameter
 {
     use Primitives\BooleanPrimitiveTrait;
+
+    /**
+     * @JMS\Type("boolean")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/PathParameter/IntegerType.php
+++ b/src/Entity/Parameters/PathParameter/IntegerType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\PathParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class IntegerType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class IntegerType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("integer")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/PathParameter/StringType.php
+++ b/src/Entity/Parameters/PathParameter/StringType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\PathParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class StringType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class StringType extends AbstractTypedParameter
 {
     use Primitives\StringPrimitiveTrait;
+
+    /**
+     * @JMS\Type("string")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/QueryParameter/ArrayType.php
+++ b/src/Entity/Parameters/QueryParameter/ArrayType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class ArrayType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class ArrayType extends AbstractTypedParameter
 {
     use Primitives\ArrayPrimitiveTrait;
+
+    /**
+     * @JMS\Type("array")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/QueryParameter/BooleanType.php
+++ b/src/Entity/Parameters/QueryParameter/BooleanType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class BooleanType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class BooleanType extends AbstractTypedParameter
 {
     use Primitives\BooleanPrimitiveTrait;
+
+    /**
+     * @JMS\Type("boolean")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/QueryParameter/IntegerType.php
+++ b/src/Entity/Parameters/QueryParameter/IntegerType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class IntegerType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class IntegerType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("integer")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/QueryParameter/NumberType.php
+++ b/src/Entity/Parameters/QueryParameter/NumberType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class NumberType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class NumberType extends AbstractTypedParameter
 {
     use Primitives\NumericPrimitiveTrait;
+
+    /**
+     * @JMS\Type("double")
+     * @var string
+     */
+    protected $default;
 }

--- a/src/Entity/Parameters/QueryParameter/StringType.php
+++ b/src/Entity/Parameters/QueryParameter/StringType.php
@@ -8,6 +8,7 @@ namespace Epfremme\Swagger\Entity\Parameters\QueryParameter;
 
 use Epfremme\Swagger\Entity\Mixin\Primitives;
 use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
+use JMS\Serializer\Annotation as JMS;
 
 /**
  * Class StringType
@@ -18,4 +19,10 @@ use Epfremme\Swagger\Entity\Parameters\AbstractTypedParameter;
 class StringType extends AbstractTypedParameter
 {
     use Primitives\StringPrimitiveTrait;
+
+    /**
+     * @JMS\Type("string")
+     * @var string
+     */
+    protected $default;
 }

--- a/tests/Entity/Parameters/FormParameter/ArrayTypeTest.php
+++ b/tests/Entity/Parameters/FormParameter/ArrayTypeTest.php
@@ -47,7 +47,7 @@ class ArrayTypeTest extends \PHPUnit_Framework_TestCase
             'required'         => false,
             'format'           => 'baz',
             'allowEmptyValues' => true,
-            'default'          => false,
+            'default'          => [],
         ]);
 
         $parameter = $this->getSerializer()->deserialize($data, AbstractParameter::class, 'json');
@@ -60,7 +60,7 @@ class ArrayTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(false, 'required', $parameter);
         $this->assertAttributeEquals('baz', 'format', $parameter);
         $this->assertAttributeEquals(true, 'allowEmptyValues', $parameter);
-        $this->assertAttributeEquals(false, 'default', $parameter);
+        $this->assertAttributeEquals([], 'default', $parameter);
 
         $json = $this->getSerializer()->serialize($parameter, 'json');
 

--- a/tests/Entity/Parameters/HeaderParameter/ArrayTypeTest.php
+++ b/tests/Entity/Parameters/HeaderParameter/ArrayTypeTest.php
@@ -47,7 +47,7 @@ class ArrayTypeTest extends \PHPUnit_Framework_TestCase
             'required'         => false,
             'format'           => 'baz',
             'allowEmptyValues' => true,
-            'default'          => false,
+            'default'          => [],
         ]);
 
         $parameter = $this->getSerializer()->deserialize($data, AbstractParameter::class, 'json');
@@ -60,7 +60,7 @@ class ArrayTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(false, 'required', $parameter);
         $this->assertAttributeEquals('baz', 'format', $parameter);
         $this->assertAttributeEquals(true, 'allowEmptyValues', $parameter);
-        $this->assertAttributeEquals(false, 'default', $parameter);
+        $this->assertAttributeEquals([], 'default', $parameter);
 
         $json = $this->getSerializer()->serialize($parameter, 'json');
 

--- a/tests/Entity/Parameters/QueryParameter/ArrayTypeTest.php
+++ b/tests/Entity/Parameters/QueryParameter/ArrayTypeTest.php
@@ -47,7 +47,7 @@ class ArrayTypeTest extends \PHPUnit_Framework_TestCase
             'required'         => false,
             'format'           => 'baz',
             'allowEmptyValues' => true,
-            'default'          => false,
+            'default'          => [],
         ]);
 
         $parameter = $this->getSerializer()->deserialize($data, AbstractParameter::class, 'json');
@@ -60,7 +60,7 @@ class ArrayTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(false, 'required', $parameter);
         $this->assertAttributeEquals('baz', 'format', $parameter);
         $this->assertAttributeEquals(true, 'allowEmptyValues', $parameter);
-        $this->assertAttributeEquals(false, 'default', $parameter);
+        $this->assertAttributeEquals([], 'default', $parameter);
 
         $json = $this->getSerializer()->serialize($parameter, 'json');
 


### PR DESCRIPTION
Probably some change in schmittjoh/serializer caused a problem with serialization - parameter's default value is casted to string, while OpenAPI specification requires it to be the same type as parameter. Unfortunately, the lib throws an error if the type is not defined (cannot be guessed), so it has to be specified in each parameter class.

ArrayType tests had to be changed in the process, because they used boolean false as a default value.